### PR TITLE
[bug fix]Fixes dozens of bugs.

### DIFF
--- a/pkg/backingservice/controller/controller.go
+++ b/pkg/backingservice/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"github.com/golang/glog"
 	backingserviceapi "github.com/openshift/origin/pkg/backingservice/api"
 	osclient "github.com/openshift/origin/pkg/client"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
@@ -23,6 +24,7 @@ func (e fatalError) Error() string {
 
 // Handle processes a namespace and deletes content in origin if its terminating
 func (c *BackingServiceController) Handle(bs *backingserviceapi.BackingService) (err error) {
+	glog.Info("bs handle called.")
 
 	if bs.Status.Phase != backingserviceapi.BackingServicePhaseActive {
 		bs.Status.Phase = backingserviceapi.BackingServicePhaseActive

--- a/pkg/backingserviceinstance/controller/controller.go
+++ b/pkg/backingserviceinstance/controller/controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	backingserviceapi "github.com/openshift/origin/pkg/backingservice/api"
 
-
 	backingserviceinstanceapi "github.com/openshift/origin/pkg/backingserviceinstance/api"
 	osclient "github.com/openshift/origin/pkg/client"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
@@ -14,14 +13,14 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"io/ioutil"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"net/http"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 // NamespaceController is responsible for participating in Kubernetes Namespace termination
@@ -43,18 +42,18 @@ func (e fatalError) Error() string {
 // Handle processes a namespace and deletes content in origin if its terminating
 func (c *BackingServiceInstanceController) Handle(bsi *backingserviceinstanceapi.BackingServiceInstance) (result error) {
 	glog.Infoln("bsi handler called.", bsi.Name)
-	
+
 	changed := false
-	
+
 	//binduuid := ""
 	var bindtime *unversioned.Time = nil
-	
+
 	// init
 	if len(bsi.Spec.Parameters) == 0 {
 		glog.Infoln("to init bsi ", bsi.Name)
-		
+
 		bsi.Spec.Parameters = make(map[string]string)
-		
+
 		//ok, bs, err := checkIfPlanidExist(c.Client, bsi.Spec.BackingServicePlanGuid)
 		//if !ok {
 		//	result = err
@@ -62,16 +61,16 @@ func (c *BackingServiceInstanceController) Handle(bsi *backingserviceinstanceapi
 		////} else {
 		////	bsi.Spec.BackingServiceName = bs.Name
 		//}
-		
+
 		bs, err := c.Client.BackingServices().Get(bsi.Spec.BackingServiceName)
 		if err != nil {
 			result = err
 			goto ERROR
 		}
-		
+
 		//bsi.Spec.BackingServiceName = bs.Spec.Name
 		//bsi.Spec.BackingServiceID = bs.Spec.Id
-		
+
 		plan_found := false
 		for _, plan := range bs.Spec.Plans {
 			if bsi.Spec.BackingServicePlanGuid == plan.Id {
@@ -80,57 +79,57 @@ func (c *BackingServiceInstanceController) Handle(bsi *backingserviceinstanceapi
 				break
 			}
 		}
-		
+
 		if ! plan_found {
 			result = fmt.Errorf("plan (%s) in bs(%s) for bsi (%s) not found", bsi.Spec.BackingServicePlanGuid, bsi.Spec.BackingServiceName, bsi.Name)
 			goto ERROR
 		}
-		
+
 		glog.Infoln("bsi inited. ", bsi.Name)
-		
-		// 
+
+		//
 		bsInstanceID := string(util.NewUUID())
 		bsi.Spec.InstanceID = bsInstanceID
 		bsi.Spec.Parameters["instance_id"] = bsInstanceID
-		
+
 		bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseCreated
 		changed = true
 	}
-	
+
 	//binduuid = bsi.Spec.BindUuid // avoid failed to unbind but etc saved
 	bindtime = bsi.Spec.BoundTime
-	
+
 UNBIND:
 
 	// unbind
 	//if bsi.Spec.Bound && binduuid == "" {
 	if bsi.Spec.Bound && bindtime == nil {
 		glog.Infoln("bsi to unbind ", bsi.Name)
-		
+
 		servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
 		if err != nil {
 			result = err
 			goto ERROR
 		}
-		
+
 		glog.Infoln("servicebroker_unbinding")
-		
+
 		_, err = servicebroker_unbinding(bsi, servicebroker)
 		if err != nil {
 			result = err
 			goto ERROR
 		}
-		
+
 		glog.Infoln("deploymentconfig_clear_envs")
-		
+
 		err = c.deploymentconfig_clear_envs(bsi)
 		if err != nil {
 			result = err
 			goto ERROR
 		}
-		
+
 		glog.Infoln("bsi is unbound ", bsi.Name)
-		
+
 		bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseActive
 		bsi.Spec.Bound = false
 		bsi.Spec.BoundTime = nil
@@ -139,14 +138,14 @@ UNBIND:
 		//binduuid = ""
 		bsi.Spec.BindDeploymentConfig = ""
 		bsi.Spec.Credentials = nil
-		
+
 		changed = true
 	}
-	
+
 	// delete
 	if bsi.Spec.InstanceID == "" {
 		glog.Infoln("bsi to delete ", bsi.Name)
-		
+
 		//if bsi.Spec.Bound && binduuid != "" {
 		if bsi.Spec.Bound && bindtime != nil {
 			//bsi.Spec.InstanceID = "" // bug
@@ -154,60 +153,60 @@ UNBIND:
 			bindtime = nil
 			goto UNBIND
 		}
-		
+
 		if bsi.Spec.BackingServiceName != "" {
 			servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
 			if err != nil {
 				result = err
 				goto ERROR
 			}
-			
+
 			glog.Infoln("deleting ", bsi.Name)
 			if _, err = servicebroker_deprovisioning(bsi, servicebroker); err != nil {
 				result = err
 				goto ERROR
 			}
 		}
-		
+
 		glog.Infoln("bsi deleted ", bsi.Name)
-		
+
 		bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseInactive
 		changed = true
 	}
-	
+
 	// delete etcd
 	if bsi.Status.Phase == backingserviceinstanceapi.BackingServiceInstancePhaseInactive {
 		err := c.Client.BackingServiceInstances(bsi.Namespace).Delete(bsi.Name)
-		
+
 		// Status.Phase should not change to BackingServiceInstancePhaseError
 		//if err != nil {
 		//	result = err
 		//	goto ERROR
 		//}
-		
+
 		glog.Infoln("bsi delete etcd ", bsi.Name, ", error: ", err)
-		
+
 		result = err
 		goto END
 	}
-	
+
 	// bind
 	if bsi.Spec.Bound == false && bsi.Spec.BindUuid != "" && bsi.Spec.BindDeploymentConfig != "" {
 		glog.Infoln("bsi to bind ", bsi.Name, " and ", bsi.Spec.BindDeploymentConfig)
-		
+
 		servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
 		if err != nil {
 			result = err
 			goto ERROR
 		}
-		
+
 		serviceinstance := &ServiceInstance{}
 		serviceinstance.ServiceId = bsi.Spec.BackingServiceSpecID
 		serviceinstance.PlanId = bsi.Spec.BackingServicePlanGuid
 		serviceinstance.OrganizationGuid = bsi.Namespace
-		
+
 		glog.Infoln("servicebroker_create_instance")
-		
+
 		svcinstance, err := servicebroker_create_instance(serviceinstance, bsi.Spec.InstanceID, servicebroker)
 		if err != nil {
 			result = err
@@ -216,25 +215,25 @@ UNBIND:
 			bsi.Spec.DashboardUrl = svcinstance.DashboardUrl
 			glog.Infoln("create instance successfully.", svcinstance)
 		}
-		
+
 		servicebinding := &ServiceBinding{
 			ServiceId:      bsi.Spec.BackingServiceSpecID,
 			PlanId:         bsi.Spec.BackingServicePlanGuid,
 			AppGuid:        bsi.Namespace,
-			//BindResource: , 
-			//Parameters: , 
+			//BindResource: ,
+			//Parameters: ,
 			svc_instance_id: bsi.Spec.InstanceID,
 		}
-		
+
 		if len(bsi.Spec.Credentials) == 0 {
 			glog.Infoln("servicebroker_binding")
-			
+
 			bindingresponse, err := servicebroker_binding(servicebinding, bsi.Spec.BindUuid, servicebroker)
 			if err != nil {
 				result = err
 				goto ERROR
 			}
-			
+
 			bsi.Spec.Credentials = make(map[string]string)
 			bsi.Spec.Credentials["Uri"] = bindingresponse.Credentials.Uri
 			bsi.Spec.Credentials["Name"] = bindingresponse.Credentials.Name
@@ -245,45 +244,45 @@ UNBIND:
 			bsi.Spec.Credentials["Vhost"] = bindingresponse.Credentials.Vhost
 			// = bindingresponse.SyslogDrainUrl
 			// = bindingresponse.RouteServiceUrl
-			
+
 			changed = true
 		}
-		
+
 		glog.Infoln("deploymentconfig_inject_envs")
-		
+
 		err = c.deploymentconfig_inject_envs(bsi)
 		if err != nil {
 			result = err
 			goto ERROR
 		}
-		
+
 		glog.Infoln("bsi bound. ", bsi.Name)
-		
+
 		bsi.Spec.Bound = true
 		now := unversioned.Now()
 		bsi.Spec.BoundTime = &now //&unversioned.Now()
-		
+
 		changed = true
 	}
 
 	// ...
-	
+
 	goto END
-	
+
 ERROR:
-	
+
 	glog.Error(result)
 	changed = changed || bsi.Status.Phase != backingserviceinstanceapi.BackingServiceInstancePhaseError
 	bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseError
-	
+
 END:
 
 	if changed {
 		glog.Infoln("bsi etc changed and update. ")
-		
+
 		c.Client.BackingServiceInstances(bsi.Namespace).Update(bsi)
 	}
-	
+
 	return result
 }
 */
@@ -291,40 +290,39 @@ END:
 // Handle processes a namespace and deletes content in origin if its terminating
 func (c *BackingServiceInstanceController) Handle(bsi *backingserviceinstanceapi.BackingServiceInstance) (result error) {
 	glog.Infoln("bsi handler called.", bsi.Name)
-	
+
 	changed := false
-	
+
+	bs, err := c.Client.BackingServices().Get(bsi.Spec.BackingServiceName)
+	if err != nil {
+		return err
+	}
+
 AGAIN:
 
 	switch bsi.Status.Phase {
 	default:
-	
+
 		result = fmt.Errorf("unknown phase: %s", bsi.Status.Phase)
-		
+
 	case backingserviceinstanceapi.BackingServiceInstancePhaseDeleted:
-		
+
 		glog.Infoln("bsi delete etcd ", bsi.Name)
-		
+
 		result = c.Client.BackingServiceInstances(bsi.Namespace).Delete(bsi.Name)
-		
+
 	case "":
-		
+
 		bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseDeleted
-		
+
 		changed = true
-		
+
 		fallthrough
-		
+
 	case backingserviceinstanceapi.BackingServiceInstancePhaseProvisioning:
-		
+
 		glog.Infoln("bsi provisioning ", bsi.Name)
-		
-		bs, err := c.Client.BackingServices().Get(bsi.Spec.BackingServiceName)
-		if err != nil {
-			result = err
-			break
-		}
-		
+
 		plan_found := false
 		for _, plan := range bs.Spec.Plans {
 			if bsi.Spec.BackingServicePlanGuid == plan.Id {
@@ -333,120 +331,121 @@ AGAIN:
 				break
 			}
 		}
-		
-		if ! plan_found {
+
+		if !plan_found {
 			result = fmt.Errorf("plan (%s) in bs(%s) for bsi (%s) not found", bsi.Spec.BackingServicePlanGuid, bsi.Spec.BackingServiceName, bsi.Name)
 			break
 		}
-		
+
 		// ...
-		
+
 		glog.Infoln("bsi provisioning servicebroker_load, ", bsi.Name)
-		
+
 		bsInstanceID := string(util.NewUUID())
-		
-		servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
+
+		servicebroker, err := servicebroker_load(c.Client, bs.GenerateName)
 		if err != nil {
 			result = err
 			break
 		}
-		
+
 		serviceinstance := &ServiceInstance{}
-		serviceinstance.ServiceId = bsi.Spec.BackingServiceSpecID
+		serviceinstance.ServiceId = bs.Spec.Id
 		serviceinstance.PlanId = bsi.Spec.BackingServicePlanGuid
 		serviceinstance.OrganizationGuid = bsi.Namespace
-		
+
 		glog.Infoln("bsi provisioning servicebroker_create_instance, ", bsi.Name)
-		
+
 		svcinstance, err := servicebroker_create_instance(serviceinstance, bsInstanceID, servicebroker)
 		if err != nil {
 			result = err
 			break
 		}
-		
+
 		glog.Infoln("bsi provisioning servicebroker_create_instance done, ", bsi.Name)
-		
+
 		bsi.Spec.DashboardUrl = svcinstance.DashboardUrl
 		//bsi.Status.LastOperation = &backingserviceinstanceapi.LastOperation{
 		//	State: svcinstance.LastOperation.State,
 		//	Description: svcinstance.LastOperation.Description,
 		//	AsyncPollIntervalSeconds: svcinstance.LastOperation.AsyncPollIntervalSeconds,
 		//}
-		
+
 		// ...
-		
+
 		bsi.Spec.InstanceID = bsInstanceID
+		bsi.Spec.BackingServiceSpecID = bs.Spec.Id
 		if bsi.Spec.Parameters == nil {
 			bsi.Spec.Parameters = make(map[string]string)
 		}
 		bsi.Spec.Parameters["instance_id"] = bsInstanceID
-		
+
 		bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseUnbound
-		
+
 		changed = true
-		
+
 		glog.Infoln("bsi inited. ", bsi.Name)
-		
+
 	case backingserviceinstanceapi.BackingServiceInstancePhaseUnbound:
-		
+
 		glog.Infoln("bsi in unbound, ", bsi.Name)
-		
+
 		if has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToDelete) {
 			glog.Infoln("bsi to delete ", bsi.Name)
-			
-			servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
+
+			servicebroker, err := servicebroker_load(c.Client, bs.GenerateName)
 			if err != nil {
 				result = err
 				break
 			}
-			
+
 			glog.Infoln("deleting ", bsi.Name)
 			if _, err = servicebroker_deprovisioning(bsi, servicebroker); err != nil {
 				result = err
 				break
 			}
-			
+
 			glog.Infoln("bsi deleted ", bsi.Name)
-			
+
 			bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseDeleted
-			
+
 			bsi.Status.Action = remove_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToDelete)
-			
+
 			changed = true
-			
+
 		} else if has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToBind) {
 			glog.Infoln("bsi to bind ", bsi.Name, " and ", bsi.Spec.BindDeploymentConfig)
-			
-			servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
+
+			servicebroker, err := servicebroker_load(c.Client, bs.GenerateName)
 			if err != nil {
 				result = err
 				break
 			}
-			
+
 			bind_uuid := string(util.NewUUID())
-			
+
 			servicebinding := &ServiceBinding{
-				ServiceId:      bsi.Spec.BackingServiceSpecID,
-				PlanId:         bsi.Spec.BackingServicePlanGuid,
-				AppGuid:        bsi.Namespace,
-				//BindResource: , 
-				//Parameters: , 
+				ServiceId: bs.Spec.Id,
+				PlanId:    bsi.Spec.BackingServicePlanGuid,
+				AppGuid:   bsi.Namespace,
+				//BindResource: ,
+				//Parameters: ,
 				svc_instance_id: bsi.Spec.InstanceID,
 			}
-			
+
 			glog.Infoln("bsi to bind 222, ", bsi.Name)
-			
+
 			if len(bsi.Spec.Credentials) == 0 {
 				glog.Infoln("servicebroker_binding")
-				
+
 				bindingresponse, err := servicebroker_binding(servicebinding, bind_uuid, servicebroker)
 				if err != nil {
 					result = err
 					break
 				}
-				
+
 				bsi.Spec.BindUuid = bind_uuid
-				
+
 				bsi.Spec.Credentials = make(map[string]string)
 				bsi.Spec.Credentials["Uri"] = bindingresponse.Credentials.Uri
 				bsi.Spec.Credentials["Name"] = bindingresponse.Credentials.Name
@@ -457,98 +456,98 @@ AGAIN:
 				bsi.Spec.Credentials["Vhost"] = bindingresponse.Credentials.Vhost
 				// = bindingresponse.SyslogDrainUrl
 				// = bindingresponse.RouteServiceUrl
-				
+
 				changed = true
 			}
-		
+
 			glog.Infoln("deploymentconfig_inject_envs")
-			
+
 			err = c.deploymentconfig_inject_envs(bsi)
 			if err != nil {
 				result = err
 				break
 			}
-			
+
 			glog.Infoln("bsi bound. ", bsi.Name)
-			
+
 			now := unversioned.Now()
 			bsi.Spec.BoundTime = &now //&unversioned.Now()
 			bsi.Spec.Bound = true
-			
+
 			bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseBound
-			
+
 			bsi.Status.Action = remove_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToBind)
-			
+
 			changed = true
 		}
-		
+
 	case backingserviceinstanceapi.BackingServiceInstancePhaseBound:
-		
+
 		glog.Infoln("bsi in bound, ", bsi.Name)
-		
-		if has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToUnbind) || 
-		  has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToDelete) {
-			
+
+		if has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToUnbind) ||
+			has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToDelete) {
+
 			glog.Infoln("bsi to unbind ", bsi.Name)
-			
-			servicebroker, err := servicebroker_load(c.Client, bsi.Spec.BackingServiceName)
+
+			servicebroker, err := servicebroker_load(c.Client, bs.GenerateName)
 			if err != nil {
 				result = err
 				break
 			}
-			
+
 			glog.Infoln("servicebroker_unbinding")
-			
+
 			_, err = servicebroker_unbinding(bsi, servicebroker)
 			if err != nil {
 				result = err
 				break
 			}
-			
+
 			glog.Infoln("deploymentconfig_clear_envs")
-			
+
 			err = c.deploymentconfig_clear_envs(bsi)
 			if err != nil {
 				result = err
 				break
 			}
-			
+
 			glog.Infoln("bsi is unbound ", bsi.Name)
-			
+
 			bsi.Spec.BindDeploymentConfig = ""
 			bsi.Spec.Credentials = nil
 			bsi.Spec.BoundTime = nil
 			bsi.Spec.BindUuid = ""
 			bsi.Spec.Bound = false
-			
+
 			bsi.Status.Phase = backingserviceinstanceapi.BackingServiceInstancePhaseUnbound
-			
+
 			bsi.Status.Action = remove_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToUnbind)
-			
+
 			changed = true
-			
+
 			if has_action_word(bsi.Status.Action, backingserviceinstanceapi.BackingServiceInstanceActionToDelete) {
 				goto AGAIN
 			}
 		}
 	}
-	
+
 	if result != nil {
 		err_msg := result.Error()
 		if err_msg != bsi.Status.Error {
 			changed = true
 			bsi.Status.Error = err_msg
 		}
-		
+
 		glog.Infoln("bsi controoler error. ", err_msg)
 	}
-	
+
 	if changed {
 		glog.Infoln("bsi etc changed and update. ")
-		
+
 		c.Client.BackingServiceInstances(bsi.Namespace).Update(bsi)
 	}
-	
+
 	return
 }
 
@@ -565,11 +564,11 @@ func remove_action_word(text, word backingserviceinstanceapi.BackingServiceInsta
 		}
 		break
 	}
-	
+
 	return text
 }
 
-func servicebroker_load(c osclient.Interface, name string) (*ServiceBroker, error){
+func servicebroker_load(c osclient.Interface, name string) (*ServiceBroker, error) {
 	servicebroker := &ServiceBroker{}
 	if sb, err := c.ServiceBrokers().Get(name); err != nil {
 		return nil, err
@@ -703,6 +702,8 @@ func servicebroker_create_instance(param *ServiceInstance, instance_guid string,
 				return nil, err
 			}
 		}
+	} else {
+		return nil, fmt.Errorf("%d returned from broker %s", resp.StatusCode, sb.Url)
 	}
 	glog.Infof("%v,%+v\n", string(body), svcinstance)
 	return svcinstance, nil
@@ -736,7 +737,7 @@ func servicebroker_binding(param *ServiceBinding, binding_guid string, sb *Servi
 	svcBinding := &ServiceBindingResponse{}
 
 	glog.Infof("%v,%+v\n", string(body), svcBinding)
-	if resp.StatusCode == http.StatusOK {
+	if resp.StatusCode == http.StatusOK ||resp.StatusCode == http.StatusCreated {
 		if len(body) > 0 {
 			err = json.Unmarshal(body, svcBinding)
 
@@ -836,9 +837,6 @@ func basicAuthStr(username, password string) string {
 	return "Basic " + authstr
 }
 
-
-
-
 var InvalidCharFinder = regexp.MustCompile("[^a-zA-Z0-9]")
 
 func deploymentconfig_env_prefix(bsiName string) string {
@@ -862,14 +860,14 @@ func env_set(envs []kapi.EnvVar, envName, envValue string) (bool, []kapi.EnvVar)
 	if envs == nil {
 		envs = []kapi.EnvVar{}
 	}
-	
-	for i := len(envs) - 1; i >= 0; i -- {
+
+	for i := len(envs) - 1; i >= 0; i-- {
 		if envs[i].Name == envName {
 			envs[i] = kapi.EnvVar{Name: envName, Value: envValue}
 			return true, envs
 		}
 	}
-	
+
 	envs = append(envs, kapi.EnvVar{Name: envName, Value: envValue})
 	return false, envs
 }
@@ -879,18 +877,18 @@ func env_unset(envs []kapi.EnvVar, envName string) (bool, []kapi.EnvVar) {
 	if envs == nil {
 		return false, nil
 	}
-	
+
 	n := len(envs)
 	index := 0
-	for i := 0; i < n; i ++ {
+	for i := 0; i < n; i++ {
 		if envs[i].Name != envName {
 			if index < i {
 				envs[index] = envs[i]
 			}
-			index ++
+			index++
 		}
 	}
-	
+
 	return index < n, envs[:index]
 }
 
@@ -899,7 +897,7 @@ func (c *BackingServiceInstanceController) deploymentconfig_modify_envs(bsi *bac
 	if err != nil {
 		return err
 	}
-	
+
 	if dc.Spec.Template == nil {
 		return nil
 	}
@@ -907,11 +905,11 @@ func (c *BackingServiceInstanceController) deploymentconfig_modify_envs(bsi *bac
 	//if err != nil {
 	//	return err
 	//}
-	
+
 	env_prefix := deploymentconfig_env_prefix(bsi.Name)
 	containers := dc.Spec.Template.Spec.Containers
 	num_containers := len(containers)
-	
+
 	if toInject {
 		//for _, c := range containers {
 		//	for k, v := range bsi.Spec.Credentials {
@@ -930,10 +928,10 @@ func (c *BackingServiceInstanceController) deploymentconfig_modify_envs(bsi *bac
 		//	}
 		//}
 		for i := 0; i < num_containers; i++ {
-			for k, _ := range bsi.Spec.Credentials {
+			for k := range bsi.Spec.Credentials {
 				_, containers[i].Env = env_unset(containers[i].Env, deploymentconfig_env_name(env_prefix, k))
 			}
-			//if containers[i].Env.VCAP_SERVICES 
+			//if containers[i].Env.VCAP_SERVICES
 		}
 	}
 
@@ -943,9 +941,9 @@ func (c *BackingServiceInstanceController) deploymentconfig_modify_envs(bsi *bac
 	if _, err := c.Client.DeploymentConfigs(bsi.Namespace).Update(dc); err != nil {
 		return err
 	}
-	
+
 	c.deploymentconfig_print_envs(bsi)
-	
+
 	return nil
 }
 
@@ -955,17 +953,17 @@ func (c *BackingServiceInstanceController) deploymentconfig_print_envs(bsi *back
 		fmt.Println("dc not found: ", bsi.Spec.BindDeploymentConfig)
 		return
 	}
-	
+
 	if dc.Spec.Template == nil {
 		fmt.Println("dc.Spec.Template is nil")
 		return
 	}
-	
+
 	containers := dc.Spec.Template.Spec.Containers
-	
+
 	for _, c := range containers {
 		fmt.Println("**********  envs in container")
-		
+
 		for _, env := range c.Env {
 			fmt.Println("     env[", env.Name, ",] = ", env.Value)
 		}

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -93,8 +93,8 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdImportImage(fullName, f, out),
 				cmd.NewCmdScale(fullName, f, out),
 				cmd.NewCmdTag(fullName, f, out),
-				cmd.NewCmdBindBackingServiceInstance(fullName+" bind-backingserviceinstance", f, out),
-				cmd.NewCmdUnbindBackingServiceInstance(fullName+" unbind-backingserviceinstance", f, out),
+				cmd.NewCmdBindBackingServiceInstance(fullName+" bind", f, out),
+				cmd.NewCmdUnbindBackingServiceInstance(fullName+" unbind", f, out),
 			},
 		},
 		{

--- a/pkg/cmd/cli/cmd/backingserviceinstance.go
+++ b/pkg/cmd/cli/cmd/backingserviceinstance.go
@@ -251,7 +251,7 @@ func NewCmdBindBackingServiceInstance(fullName string, f *clientcmd.Factory, out
 	options := &BindBackingServiceInstanceOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "bind-backingserviceinstance BackingServiceInstanceName DeployConfigName",
+		Use:     "bind BackingServiceInstanceName DeployConfigName",
 		Short:   "bind a BackingServiceInstance and a DeployConfig",
 		Long:    bindBackingServiceInstanceLong,
 		Example: fmt.Sprintf(bindBackingServiceInstanceExample, fullName),
@@ -349,7 +349,7 @@ func NewCmdUnbindBackingServiceInstance(fullName string, f *clientcmd.Factory, o
 	options := &UnbindBackingServiceInstanceOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "unbind-backingserviceinstance BackingServiceInstanceName DeployConfigName",
+		Use:     "unbind BackingServiceInstanceName DeployConfigName",
 		Short:   "unbind a BackingServiceInstance and a DeployConfig",
 		Long:    unbindBackingServiceInstanceLong,
 		Example: fmt.Sprintf(unbindBackingServiceInstanceExample, fullName),

--- a/pkg/project/controller/controller.go
+++ b/pkg/project/controller/controller.go
@@ -9,7 +9,6 @@ import (
 
 	osclient "github.com/openshift/origin/pkg/client"
 	projectutil "github.com/openshift/origin/pkg/project/util"
-	"github.com/golang/glog"
 )
 
 // NamespaceController is responsible for participating in Kubernetes Namespace termination
@@ -29,7 +28,7 @@ func (e fatalError) Error() string { return "fatal error handling namespace: " +
 
 // Handle processes a namespace and deletes content in origin if its terminating
 func (c *NamespaceController) Handle(namespace *kapi.Namespace) (err error) {
-	glog.Info("project handler called.")
+
 	// if namespace is not terminating, ignore it
 	if namespace.Status.Phase != kapi.NamespaceTerminating {
 		return nil

--- a/pkg/servicebroker/controller/controller.go
+++ b/pkg/servicebroker/controller/controller.go
@@ -1,15 +1,14 @@
 package controller
 
 import (
-	"fmt"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	osclient "github.com/openshift/origin/pkg/client"
 	servicebrokerapi "github.com/openshift/origin/pkg/servicebroker/api"
 
+	"github.com/golang/glog"
 	backingservice "github.com/openshift/origin/pkg/backingservice/api"
 	servicebrokerclient "github.com/openshift/origin/pkg/servicebroker/client"
-	"time"
 )
 
 // NamespaceController is responsible for participating in Kubernetes Namespace termination
@@ -38,28 +37,42 @@ func (c *ServiceBrokerController) Handle(sb *servicebrokerapi.ServiceBroker) (er
 
 	services, err := c.ServiceBrokerClient.Catalog(sb.Spec.Url, sb.Spec.UserName, sb.Spec.Password)
 	if err != nil {
-		fmt.Printf("ServiceBroker %s catalog err %s\n", sb.Name, err.Error())
-		time.Sleep(time.Minute * 5)
-		sb.Status.Phase = servicebrokerapi.ServiceBrokerFailed
-		c.Client.ServiceBrokers().Update(sb)
+		glog.Infof("ServiceBroker %s catalog err %s\n", sb.Name, err.Error())
+		//time.Sleep(time.Minute * 5)
+		if sb.Status.Phase != servicebrokerapi.ServiceBrokerFailed {
+			sb.Status.Phase = servicebrokerapi.ServiceBrokerFailed
+			c.Client.ServiceBrokers().Update(sb)
+		}
 
 		return nil
 	}
 
+	finish := false
 	for _, v := range services.Services {
 		backingService := &backingservice.BackingService{}
 		backingService.Spec = backingservice.BackingServiceSpec(v)
 		backingService.Annotations = make(map[string]string)
-		backingService.Name = sb.Name
-		backingService.GenerateName = v.Name
+		backingService.Name = v.Name
+		backingService.GenerateName = sb.Name
 		backingService.Labels = map[string]string{
 			servicebrokerapi.ServiceBrokerLabel: sb.Name,
 		}
-
+		glog.Info("create backingservice")
 		if _, err := c.Client.BackingServices().Create(backingService); err == nil {
-			sb.Status.Phase = servicebrokerapi.ServiceBrokerActive
-			c.Client.ServiceBrokers().Update(sb)
+			glog.Info("create backingservice successfuly!", backingService)
+			finish = true
+		} else {
+			glog.Info(err)
+			return err
 		}
+	}
+	if finish == true {
+		//TODO
+	}
+
+	if sb.Status.Phase != servicebrokerapi.ServiceBrokerActive {
+		sb.Status.Phase = servicebrokerapi.ServiceBrokerActive
+		c.Client.ServiceBrokers().Update(sb)
 	}
 
 	return nil


### PR DESCRIPTION
Fixed: Empty service_id would cause a failer of calling deprovisioning/unbind api.
Service name should not be same as servicebroker name, since a broker may supply multiply services.
Provisioning api returns HTTP 200 or 201 if success. Now controller processes api response correctly.
Change oc bind/unbind-backingserviceinstance command to shorter name.
Serviceroker controller doesn't sleep 5 mins anymore.